### PR TITLE
优先用translation字段翻译，加Api请求1秒间隔

### DIFF
--- a/cmd/QtTranser/QtTranser.go
+++ b/cmd/QtTranser/QtTranser.go
@@ -71,6 +71,7 @@ func Trans(args QtTransArgs) {
 		To:     args.TargetLan,
 	}
 	alreadyTranNum := 0
+	baidu.ResetFailedCnt()
 	transData.Language = args.TargetLan
 	for i := 0; i < len(transData.Contexts); i++ {
 		ctx := &transData.Contexts[i]

--- a/cmd/QtTranser/QtTranser.go
+++ b/cmd/QtTranser/QtTranser.go
@@ -70,12 +70,17 @@ func Trans(args QtTransArgs) {
 		Secret: args.Secret,
 		To:     args.TargetLan,
 	}
+	alreadyTranNum := 0
 	transData.Language = args.TargetLan
 	for i := 0; i < len(transData.Contexts); i++ {
 		ctx := &transData.Contexts[i]
 		for j := 0; j < len(ctx.Messages); j++ {
 			msg := &ctx.Messages[j]
-			input.Query = msg.Source
+			if msg.Trans.Trans != "" {
+				input.Query = msg.Trans.Trans
+			} else {
+				input.Query = msg.Source
+			}
 			if args.API == "baidu" {
 				ans := baidu.Trans(input)
 				if ans.Result != "" {
@@ -89,8 +94,11 @@ func Trans(args QtTransArgs) {
 					msg.Trans.Type = ""
 				}
 			}
+			alreadyTranNum++
+			fmt.Printf("translate %d words already.\r\n", alreadyTranNum)
 		}
 	}
+	fmt.Printf("baidu translate %d words failed.\r\n", baidu.GetFailedCnt())
 
 	res, err := xml.MarshalIndent(&transData, "", "    ")
 	if err != nil {

--- a/services/baidu/baidu.go
+++ b/services/baidu/baidu.go
@@ -151,6 +151,11 @@ func GetFailedCnt() int {
 	return gFailedCnt
 }
 
+//ResetFailedCnt ResetFailedCnt
+func ResetFailedCnt() {
+	gFailedCnt = 0
+}
+
 //Trans trans
 func Trans(input *transer.TransInput) *transer.TransOutput {
 	output := new(transer.TransOutput)

--- a/services/baidu/baidu.go
+++ b/services/baidu/baidu.go
@@ -143,6 +143,14 @@ type result struct {
 	TransResult []transItem `json:"trans_result"`
 }
 
+var glastApiTime int64
+var gFailedCnt int //翻译失败总数量
+
+//GetFailedCnt GetFailedCnt
+func GetFailedCnt() int {
+	return gFailedCnt
+}
+
 //Trans trans
 func Trans(input *transer.TransInput) *transer.TransOutput {
 	output := new(transer.TransOutput)
@@ -160,19 +168,25 @@ func Trans(input *transer.TransInput) *transer.TransOutput {
 	values["appid"] = []string{input.ID}
 	values["salt"] = []string{salt}
 	values["sign"] = []string{signStr}
+	crtTime := time.Now().UnixNano()
+	tmWait := 1e9 - (crtTime - glastApiTime)
+	if tmWait > 0 {
+		time.Sleep(time.Duration(tmWait)) //免费用户1秒只能请求一次
+	}
 	res, err := http.PostForm(baiduAPI, values)
 	if err != nil {
 		fmt.Println(err)
 		return output
 	}
 	defer res.Body.Close()
+	glastApiTime = time.Now().UnixNano()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		fmt.Println(err)
 		return output
 	}
-	// fmt.Println(string(body))
+	//fmt.Println("ret:" + string(body))
 	r := &result{}
 	err = json.Unmarshal(body, &r)
 	if err != nil {
@@ -183,6 +197,8 @@ func Trans(input *transer.TransInput) *transer.TransOutput {
 		// fmt.Println(r.TransResult[0].Src)
 		// fmt.Println(r.TransResult[0].Dst)
 		output.Result = r.TransResult[0].Dst
+	} else {
+		gFailedCnt++
 	}
 	return output
 }


### PR DESCRIPTION
1.修改翻译输入文件已经翻译时使用翻译字符translation进行翻译请求，否则还是使用source
2.修改百度翻译Api请求调用间隔控制在1秒1次（受百度免费api账户限制，过快会翻译失败）
